### PR TITLE
fix: roll own dup as crystals is borked

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: clustering
-version: 2.0.2
+version: 2.0.3
 crystal: ~> 0.35
 license: MIT
 

--- a/src/clustering.cr
+++ b/src/clustering.cr
@@ -239,10 +239,33 @@ class Clustering
   def handle_version_change(value)
     version = value.first?.try(&.kv.value) || ""
     Log.debug { {is_leader: leader?, version: version, message: "received version change"} }
-    stabilize_channel.send({discovery.nodes.dup, version})
+    stabilize_channel.send({dup(discovery.nodes), version})
   rescue e
     Log.error(exception: e) { "error while watching cluster version" }
   end
+
+  # Unfortunate hack for crystal v0.36.0
+  #################################################################################################
+
+  @[AlwaysInline]
+  private def dup(hash : Hash(K, V)) forall K, V
+    new_hash = Hash(K, V).new
+    hash.each do |k, v|
+      new_hash[k] = v
+    end
+    new_hash
+  end
+
+  @[AlwaysInline]
+  private def dup(ary : Array(V)) forall V
+    new_ary = Array(V).new
+    ary.each do |v|
+      new_ary << v
+    end
+    new_ary
+  end
+
+  #################################################################################################
 
   # The leader calls the `on_stable` callback if...
   # + cluster's version state is consistent
@@ -250,7 +273,7 @@ class Clustering
   def handle_readiness_event
     if leader? && cluster_consistent? && previous_node_versions != node_versions
       Log.info { {message: "cluster stable", version: cluster_version} }
-      @previous_node_versions = @node_versions.dup
+      @previous_node_versions = dup(@node_versions)
       on_stable.try &.call(cluster_version)
     end
   rescue e


### PR DESCRIPTION
Getting this stack trace, so I decided to roll my own dup

```
In lib/clustering/src/clustering.cr:271:48

 271 | @previous_node_versions = @node_versions.dup
                                                ^--
Error: instantiating 'Hash(String, String)+#dup()'


In /usr/local/Cellar/crystal/0.36.0/src/hash.cr:1775:23

 1775 | hash = self.class.new
                          ^--
Error: wrong number of arguments for 'Hash(String, String)#initialize' (given 0, expected 3)
```